### PR TITLE
fix install zigbee2mqtt

### DIFF
--- a/sections/install_zigbee2mqtt.sh
+++ b/sections/install_zigbee2mqtt.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 
 showMessage "Installing Zigbee2MQTT..."
+runSudo "curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -"
+runSudo "apt-get install -y nodejs git make g++ gcc"
+runSudo " mkdir /opt/zigbee2mqtt"
 
-runSudo "apt-get install -y nodejs npm"
-runSudo "apt-get install -y yarn"
-runSudo "git clone https://github.com/Koenkk/zigbee2mqtt.git /opt/zigbee2mqtt"
+runSudo "git clone --depth 1 https://github.com/Koenkk/zigbee2mqtt.git /opt/zigbee2mqtt"
 runSudo "chown -R pi:pi /opt/zigbee2mqtt"
 
 sudo echo "frontend:">>/opt/zigbee2mqtt/data/configuration.yaml


### PR DESCRIPTION
В последних версиях установки сервиса zigbee2mqtt используется node версии node --version  # Should output v14.X, V16.x, V17.x or V18.X Ранее при установки ставилась версия node 12.x и соответственно сама установка  сервиса z2m происходила с ошибкой. Изменил команды в соответствии с документацией по установке zigbee2mqtt

https://www.zigbee2mqtt.io/guide/installation/01_linux.html