### PR TITLE
Update npm to 20.x

### DIFF
--- a/sections/install_zigbee2mqtt.sh
+++ b/sections/install_zigbee2mqtt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 showMessage "Installing Zigbee2MQTT..."
-curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
 runSudo "apt-get install -y nodejs"
 runSudo "apt-get install -y make"
 runSudo "apt-get install -y g++"


### PR DESCRIPTION
В последних версиях установки сервиса zigbee2mqtt используются node версии node --version  # Should output V18.x, V20.x, V21.X
 
 Ранее при установки ставилась версия node 16.x и соответственно сама установка сервиса z2m происходила с warning.
Изменил команды в соответствии с документацией по установке zigbee2mqtt на установку 20 версии

https://www.zigbee2mqtt.io/guide/installation/01_linux.html